### PR TITLE
Browser Back now navigates one app step back

### DIFF
--- a/src/components/Todo.js
+++ b/src/components/Todo.js
@@ -109,20 +109,77 @@ function Todo() {
     });
   };
 
+  useEffect(() => {
+    if (typeof window !== "undefined") {
+      window.history.replaceState(
+        { selectedBoard: null, isPanelOpen: true },
+        "",
+        window.location.pathname
+      );
+
+      const handlePopState = (event) => {
+        const state = event.state;
+        if (state) {
+          setSelectedBoard(state.selectedBoard || null);
+          setIsPanelOpen(state.isPanelOpen ?? true);
+        } else {
+          setSelectedBoard(null);
+          setIsPanelOpen(true);
+        }
+      };
+
+      window.addEventListener("popstate", handlePopState);
+      return () => window.removeEventListener("popstate", handlePopState);
+    }
+    return undefined;
+  }, []);
+
   const handleSelectBoard = (boardId) => {
     setSelectedBoard(boardId);
     setIsPanelOpen(false);
+    if (typeof window !== "undefined") {
+      window.history.pushState(
+        { selectedBoard: boardId, isPanelOpen: false },
+        "",
+        window.location.pathname
+      );
+    }
   };
 
   const handleGoBack = () => {
     setSelectedBoard(null);
     setIsPanelOpen(true);
+    if (typeof window !== "undefined") {
+      window.history.pushState(
+        { selectedBoard: null, isPanelOpen: true },
+        "",
+        window.location.pathname
+      );
+    }
+  };
+
+  const openBoardPanel = () => {
+    setIsPanelOpen(true);
+    if (typeof window !== "undefined") {
+      window.history.pushState(
+        { selectedBoard, isPanelOpen: true },
+        "",
+        window.location.pathname
+      );
+    }
   };
 
   // Automatically close dashboard when clicking on main content
   const handleMainClick = () => {
     if (isPanelOpen && selectedBoard) {
       setIsPanelOpen(false);
+      if (typeof window !== "undefined") {
+        window.history.pushState(
+          { selectedBoard, isPanelOpen: false },
+          "",
+          window.location.pathname
+        );
+      }
     }
   };
 
@@ -191,7 +248,7 @@ function Todo() {
           >
             {selectedBoard && !isPanelOpen && (
               <IconButton
-                onClick={() => setIsPanelOpen(true)}
+                onClick={openBoardPanel}
                 disableRipple
                 disableFocusRipple
                 disableTouchRipple


### PR DESCRIPTION
Added browser history handling in Todo.js
Replaced the initial state with history.replaceState(...)
Added window.history.pushState(...) when:
selecting a board
going back from a board
opening the board panel
closing the board panel via main-content click
Added a popstate listener so browser Back updates app state instead of reloading